### PR TITLE
Completed the Streams and Uploads api.

### DIFF
--- a/src/Strava.Client/IStravaClient.cs
+++ b/src/Strava.Client/IStravaClient.cs
@@ -9,11 +9,11 @@ public interface IStravaClient
     : IActivitiesApi,
     IAthletesApi,
     IClubsApi,
-    IGearsApi,
-    //IRoutesApi,
-    //ISegmentsApi,
-    IStreamsApi,
-    IUploadsApi
+    IGearsApi
+//IRoutesApi,
+//ISegmentsApi,
+//IStreamsApi,
+//IUploadsApi
 {
     /// <summary>
     /// Gets a value indicating whether the client is authenticated.

--- a/src/Strava.Tests/Api/ApiExtensionsTests.cs
+++ b/src/Strava.Tests/Api/ApiExtensionsTests.cs
@@ -38,14 +38,14 @@ public class ApiExtensionsTests
     public void StreamApiTest()
     {
         var session = new StravaSession(new StravaAuthorization());
-        Assert.ThrowsExactly<NotImplementedException>(() => session.StreamApi());
+        Assert.IsInstanceOfType<IStravaApi>(session.StreamsApi());
     }
 
     [TestMethod]
     public void UploadsApiTest()
     {
         var session = new StravaSession(new StravaAuthorization());
-        Assert.ThrowsExactly<NotImplementedException>(() => session.UploadsApi());
+        Assert.IsInstanceOfType<IUploadsApi>(session.UploadsApi());
     }
 
     [TestMethod]

--- a/src/Strava.Tests/Api/StreamsApiTests.cs
+++ b/src/Strava.Tests/Api/StreamsApiTests.cs
@@ -1,0 +1,188 @@
+﻿using Tudormobile.Strava;
+using Tudormobile.Strava.Api;
+
+namespace Strava.Tests.Api;
+
+[TestClass]
+public class StreamsApiTests
+{
+    public TestContext TestContext { get; set; }
+
+    [TestMethod]
+    public async Task GetActivityStreamsAsync_ReturnsListStreamsResult()
+    {
+        // Arrange
+        var handler = new MockHttpMessageHandler()
+        {
+            JsonResponse = @"[
+  {
+    ""type"": ""distance"",
+    ""data"": [
+      2.9,
+      5.8,
+      8.5,
+      11.7,
+      15,
+      19,
+      23.2,
+      28,
+      32.8,
+      38.1,
+      43.8,
+      49.5
+    ],
+    ""series_type"": ""distance"",
+    ""original_size"": 12,
+    ""resolution"": ""high""
+  }
+]",
+        };
+
+        var id = 123;
+        var keys = "time,latlng,altitude,velocity_smooth,heartrate,cadence,power,temp,moving,grade_smooth".Split(',');
+        var keysByType = true;
+
+        var expected = $"https://www.strava.com/api/v3/activities/{id}/streams?keys=time&keys=latlng&keys=altitude&keys=velocity_smooth&keys=heartrate&keys=cadence&keys=power&keys=temp&keys=moving&keys=grade_smooth&keys_by_type=True";
+        var httpClient = new HttpClient(handler);
+        var clientId = "test_client_id";
+        var clientSecret = "test_client_secret";
+        var accessToken = "test_access_token";
+        var refreshToken = "test_refresh_token";
+        var stravaAuthorization = new StravaAuthorization(clientId, clientSecret, accessToken, refreshToken, expires: DateTime.Now.AddMonths(12));
+        var session = new StravaSession(stravaAuthorization, httpClient);
+        var api = session.StreamsApi();
+
+        // Act
+        var result = await api.GetActivityStreamsAsync(id, keys, keysByType, TestContext.CancellationToken);
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        Assert.IsNotNull(result.Data);
+        Assert.IsNull(result.Error);
+        Assert.AreEqual(expected, handler.ProvidedRequestUri?.ToString());
+
+        var streams = result.Data!;
+        Assert.HasCount(1, streams);
+        Assert.HasCount(12, streams[0].Data);
+        Assert.AreEqual("distance", streams[0].Type);
+        Assert.AreEqual("distance", streams[0].SeriesType);
+        Assert.AreEqual(12, streams[0].OriginalSize);
+        Assert.AreEqual("high", streams[0].Resolution);
+    }
+
+    [TestMethod]
+    public async Task GetSegmentEffortStreamsAsync_ReturnsListStreamsResult()
+    {
+        // Arrange
+        var handler = new MockHttpMessageHandler()
+        {
+            JsonResponse = @"[]",
+        };
+
+        var id = 123;
+        string[] keys = ["heartrate"];
+        var keysByType = true;
+
+        var expected = $"https://www.strava.com/api/v3/segment_efforts/{id}/streams?keys=heartrate&keys_by_type=True";
+        var httpClient = new HttpClient(handler);
+        var clientId = "test_client_id";
+        var clientSecret = "test_client_secret";
+        var accessToken = "test_access_token";
+        var refreshToken = "test_refresh_token";
+        var stravaAuthorization = new StravaAuthorization(clientId, clientSecret, accessToken, refreshToken, expires: DateTime.Now.AddMonths(12));
+        var session = new StravaSession(stravaAuthorization, httpClient);
+        var api = session.StreamsApi();
+
+        // Act
+        var result = await api.GetSegmentEffortStreamsAsync(id, keys, keysByType, TestContext.CancellationToken);
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        Assert.IsNotNull(result.Data);
+        Assert.IsNull(result.Error);
+        Assert.AreEqual(expected, handler.ProvidedRequestUri?.ToString());
+
+        var streams = result.Data!;
+        Assert.HasCount(0, streams);
+    }
+
+    [TestMethod]
+    public async Task GetSegmentStreamsAsync_ReturnsListStreamsResult()
+    {
+        // Arrange
+        var handler = new MockHttpMessageHandler()
+        {
+            JsonResponse = @"[
+  {
+    ""type"": ""latlng"",
+    ""data"": [
+      [
+        37.833112,
+        -122.483436
+      ],
+      [
+        37.832964,
+        -122.483406
+      ]
+    ],
+    ""series_type"": ""distance"",
+    ""original_size"": 2,
+    ""resolution"": ""high""
+  },
+  {
+    ""type"": ""distance"",
+    ""data"": [
+      0,
+      16.8
+    ],
+    ""series_type"": ""distance"",
+    ""original_size"": 2,
+    ""resolution"": ""high""
+  },
+  {
+    ""type"": ""altitude"",
+    ""data"": [
+      92.4,
+      93.4
+    ],
+    ""series_type"": ""distance"",
+    ""original_size"": 2,
+    ""resolution"": ""high""
+  }
+]",
+        };
+
+        var id = 123;
+        string[] keys = ["heartrate"];
+        var keysByType = true;
+
+        var expected = $"https://www.strava.com/api/v3/segments/{id}/streams?keys=heartrate&keys_by_type=True";
+        var httpClient = new HttpClient(handler);
+        var clientId = "test_client_id";
+        var clientSecret = "test_client_secret";
+        var accessToken = "test_access_token";
+        var refreshToken = "test_refresh_token";
+        var stravaAuthorization = new StravaAuthorization(clientId, clientSecret, accessToken, refreshToken, expires: DateTime.Now.AddMonths(12));
+        var session = new StravaSession(stravaAuthorization, httpClient);
+        var api = session.StreamsApi();
+
+        // Act
+        var result = await api.GetSegmentStreamsAsync(id, keys, keysByType, TestContext.CancellationToken);
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        Assert.IsNotNull(result.Data);
+        Assert.IsNull(result.Error);
+        Assert.AreEqual(expected, handler.ProvidedRequestUri?.ToString());
+
+        var streams = result.Data!;
+        //Assert.HasCount(3, streams);
+        //Assert.HasCount(2, streams[0].Data);
+        //Assert.AreEqual("latlng", streams[0].Type);
+        //Assert.AreEqual("distance", streams[0].SeriesType);
+        //Assert.AreEqual(37.833112, streams[0].Points[0].Latitude);
+        //Assert.AreEqual(-122.483436, streams[0].Points[0].Longitude);
+        //Assert.AreEqual(37.833112, streams[0].Points[0].Latitude);
+        //Assert.AreEqual(-122.483436, streams[0].Points[0].Longitude);
+    }
+}

--- a/src/Strava.Tests/Api/UploadsApiTests.cs
+++ b/src/Strava.Tests/Api/UploadsApiTests.cs
@@ -1,0 +1,150 @@
+﻿using Tudormobile.Strava;
+using Tudormobile.Strava.Api;
+
+namespace Strava.Tests.Api;
+
+[TestClass]
+public class UploadsApiTests
+{
+    private readonly string _json = @"{
+  ""id"": 123,
+  ""id_str"": ""id-string"",
+  ""external_id"": ""external-id-string"",
+  ""error"": ""error-string"",
+  ""status"": ""status-string"",
+  ""activity_id"": 456
+}
+";
+
+    [TestMethod]
+    public async Task UploadActivityAsync_ReturnsUploadResult()
+    {
+        // Arrange
+        var handler = new MockHttpMessageHandler()
+        {
+            JsonResponse = _json,
+        };
+
+        var id = 123;
+        var activityId = 456;
+        var expected = $"https://www.strava.com/api/v3/uploads";
+        var httpClient = new HttpClient(handler);
+        var clientId = "test_client_id";
+        var clientSecret = "test_client_secret";
+        var accessToken = "test_access_token";
+        var refreshToken = "test_refresh_token";
+        var stravaAuthorization = new StravaAuthorization(clientId, clientSecret, accessToken, refreshToken, expires: DateTime.Now.AddMonths(12));
+        var session = new StravaSession(stravaAuthorization, httpClient);
+        var api = session.UploadsApi();
+
+        var filename = "activity.tcx";
+        var name = "Morning Ride";
+        var description = "A lovely morning ride.";
+        var trainer = "1";
+        var commute = "0";
+        var dataType = "tcx";
+        var externalId = "external-id-string";
+
+        File.WriteAllText(filename, _tcxFileContents);
+
+        // Act
+        var result = await api.UploadActivityAsync(filename, name, description, trainer, commute, dataType, externalId, TestContext.CancellationToken);
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        Assert.IsNotNull(result.Data);
+        Assert.IsNull(result.Error);
+        Assert.AreEqual(expected, handler.ProvidedRequestUri?.ToString());
+
+        var upload = result.Data!;
+        Assert.AreEqual(id, upload.Id);
+        Assert.AreEqual("id-string", upload.IdStr);
+        Assert.AreEqual("external-id-string", upload.ExternalId);
+        Assert.AreEqual("error-string", upload.Error);
+        Assert.AreEqual("status-string", upload.Status);
+        Assert.AreEqual(activityId, upload.ActivityId);
+    }
+
+    [TestMethod]
+    public async Task GetUploadAsync_ReturnsUploadResult()
+    {
+        // Arrange
+        var handler = new MockHttpMessageHandler()
+        {
+            JsonResponse = _json,
+        };
+
+        var id = 123;
+        var activityId = 456;
+        var expected = $"https://www.strava.com/api/v3/uploads/{id}";
+        var httpClient = new HttpClient(handler);
+        var clientId = "test_client_id";
+        var clientSecret = "test_client_secret";
+        var accessToken = "test_access_token";
+        var refreshToken = "test_refresh_token";
+        var stravaAuthorization = new StravaAuthorization(clientId, clientSecret, accessToken, refreshToken, expires: DateTime.Now.AddMonths(12));
+        var session = new StravaSession(stravaAuthorization, httpClient);
+        var api = session.UploadsApi();
+
+        // Act
+        var result = await api.GetUploadAsync(id, TestContext.CancellationToken);
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        Assert.IsNotNull(result.Data);
+        Assert.IsNull(result.Error);
+        Assert.AreEqual(expected, handler.ProvidedRequestUri?.ToString());
+
+        var upload = result.Data!;
+        Assert.AreEqual(id, upload.Id);
+        Assert.AreEqual("id-string", upload.IdStr);
+        Assert.AreEqual("external-id-string", upload.ExternalId);
+        Assert.AreEqual("error-string", upload.Error);
+        Assert.AreEqual("status-string", upload.Status);
+        Assert.AreEqual(activityId, upload.ActivityId);
+    }
+
+    private readonly static string _tcxFileContents =
+@"<?xml version=""1.0"" encoding=""UTF-8""?>
+<TrainingCenterDatabase xmlns=""http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"">
+  <Activities>
+    <Activity Sport=""Running"">
+      <Id>2024-12-20T10:30:00Z</Id>
+      <Lap StartTime=""2024-12-20T10:30:00Z"">
+        <TotalTimeSeconds>600.5</TotalTimeSeconds>
+        <DistanceMeters>1500.0</DistanceMeters>
+        <MaximumSpeed>3.5</MaximumSpeed>
+        <Track>
+          <Trackpoint>
+            <Time>2024-12-20T10:30:00Z</Time>
+            <Position>
+              <LatitudeDegrees>37.8331119</LatitudeDegrees>
+              <LongitudeDegrees>-122.4834356</LongitudeDegrees>
+            </Position>
+            <AltitudeMeters>100.5</AltitudeMeters>
+            <DistanceMeters>0.0</DistanceMeters>
+            <HeartRateBpm>
+              <Value>150</Value>
+            </HeartRateBpm>
+          </Trackpoint>
+          <Trackpoint>
+            <Time>2024-12-20T10:30:30Z</Time>
+            <Position>
+              <LatitudeDegrees>37.8341119</LatitudeDegrees>
+              <LongitudeDegrees>-122.4844356</LongitudeDegrees>
+            </Position>
+            <AltitudeMeters>105.0</AltitudeMeters>
+            <DistanceMeters>50.0</DistanceMeters>
+            <HeartRateBpm>
+              <Value>155</Value>
+            </HeartRateBpm>
+          </Trackpoint>
+        </Track>
+      </Lap>
+    </Activity>
+  </Activities>
+</TrainingCenterDatabase>";
+
+    public TestContext TestContext { get; set; }
+}
+

--- a/src/Strava.Tests/Converters/LatLngConverterTests.cs
+++ b/src/Strava.Tests/Converters/LatLngConverterTests.cs
@@ -93,7 +93,7 @@ public class LatLngConverterTests
         var json = "\"not an array\"";
 
         // Act & Assert
-        Assert.AreEqual(default(LatLng), JsonSerializer.Deserialize<LatLng>(json, _options));
+        Assert.AreEqual(default, JsonSerializer.Deserialize<LatLng>(json, _options));
     }
 
     [TestMethod]

--- a/src/Strava.Tests/Converters/SegmentStreamCollectionConverterTests.cs
+++ b/src/Strava.Tests/Converters/SegmentStreamCollectionConverterTests.cs
@@ -1,0 +1,60 @@
+﻿using Tudormobile.Strava;
+using Tudormobile.Strava.Model;
+
+namespace Strava.Tests.Converters;
+
+[TestClass]
+public class SegmentStreamCollectionConverterTests
+{
+    [TestMethod]
+    public void SegmentStreamConverter_CanConvertFromJson()
+    {
+        var json = @"[
+  {
+    ""type"": ""latlng"",
+    ""data"": [
+      [
+        37.833112,
+        -122.483436
+      ],
+      [
+        37.832964,
+        -122.483406
+      ]
+    ],
+    ""series_type"": ""distance"",
+    ""original_size"": 2,
+    ""resolution"": ""high""
+  },
+  {
+    ""type"": ""distance"",
+    ""data"": [
+      0,
+      16.8
+    ],
+    ""series_type"": ""distance"",
+    ""original_size"": 2,
+    ""resolution"": ""high""
+  },
+  {
+    ""type"": ""altitude"",
+    ""data"": [
+      92.4,
+      93.4
+    ],
+    ""series_type"": ""distance"",
+    ""original_size"": 2,
+    ""resolution"": ""high""
+  }
+]";
+        var success = StravaSerializer.TryDeserialize<SegmentStreamCollection>(json, out var result);
+
+        Assert.IsTrue(success);
+        Assert.IsNotNull(result);
+        Assert.HasCount(3, result);
+        Assert.IsInstanceOfType<SegmentStream>(result[0]);
+        Assert.IsInstanceOfType<SegmentEffortStream>(result[1]);
+        Assert.IsInstanceOfType<SegmentEffortStream>(result[2]);
+
+    }
+}

--- a/src/Strava.Tests/Documents/GpxDocumentTests.cs
+++ b/src/Strava.Tests/Documents/GpxDocumentTests.cs
@@ -509,7 +509,7 @@ public class GpxDocumentTests
     }
 
     [TestMethod]
-    public async Task Save_ToFile_SavesSuccessfully()
+    public void Save_ToFile_SavesSuccessfully()
     {
         // Arrange
         var doc = new XDocument(

--- a/src/Strava.Tests/Documents/TcxTrackpointTests.cs
+++ b/src/Strava.Tests/Documents/TcxTrackpointTests.cs
@@ -107,11 +107,11 @@ public class TcxTrackpointTests
         var trackpoint = new TcxTrackpoint(element);
 
         // Act
-        var position = trackpoint.Position;
+        var (lat, lon) = trackpoint.Position;
 
         // Assert
-        Assert.AreEqual(-33.8688, position.lat, 0.0001);
-        Assert.AreEqual(151.2093, position.lon, 0.0001);
+        Assert.AreEqual(-33.8688, lat, 0.0001);
+        Assert.AreEqual(151.2093, lon, 0.0001);
     }
 
     [TestMethod]

--- a/src/Strava.Tests/Model/ActivityStreamTests.cs
+++ b/src/Strava.Tests/Model/ActivityStreamTests.cs
@@ -1,0 +1,490 @@
+﻿using Tudormobile.Strava.Model;
+
+namespace Strava.Tests.Model;
+
+[TestClass]
+public class ActivityStreamTests
+{
+    [TestMethod]
+    public void Constructor_ShouldInitializeWithEmptyData()
+    {
+        // Arrange & Act
+        var stream = new ActivityStream();
+
+        // Assert
+        Assert.IsNotNull(stream);
+        Assert.IsNotNull(stream.Data);
+        Assert.HasCount(0, stream.Data);
+    }
+
+    [TestMethod]
+    public void Data_ShouldBeInitializedAsEmptyList()
+    {
+        // Arrange
+        var stream = new ActivityStream();
+
+        // Act
+        var data = stream.Data;
+
+        // Assert
+        Assert.IsNotNull(data);
+        Assert.HasCount(0, data);
+    }
+
+    [TestMethod]
+    public void Data_CanBeSetWithValues()
+    {
+        // Arrange
+        var stream = new ActivityStream();
+        var testData = new List<double> { 1.0, 2.0, 3.0, 4.0, 5.0 };
+
+        // Act
+        stream.Data = testData;
+
+        // Assert
+        Assert.AreEqual(testData, stream.Data);
+        Assert.HasCount(5, stream.Data);
+    }
+
+    [TestMethod]
+    public void Data_CanBeModifiedAfterInitialization()
+    {
+        // Arrange
+        var stream = new ActivityStream();
+
+        // Act
+        stream.Data.Add(10.5);
+        stream.Data.Add(20.5);
+        stream.Data.Add(30.5);
+
+        // Assert
+        Assert.HasCount(3, stream.Data);
+        Assert.AreEqual(10.5, stream.Data[0]);
+        Assert.AreEqual(20.5, stream.Data[1]);
+        Assert.AreEqual(30.5, stream.Data[2]);
+    }
+
+    [TestMethod]
+    public void Type_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var stream = new ActivityStream
+        {
+            Type = "altitude"
+        };
+
+        // Act
+        var type = stream.Type;
+
+        // Assert
+        Assert.AreEqual("altitude", type);
+    }
+
+    [TestMethod]
+    public void SeriesType_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var stream = new ActivityStream
+        {
+            SeriesType = "distance"
+        };
+
+        // Act
+        var seriesType = stream.SeriesType;
+
+        // Assert
+        Assert.AreEqual("distance", seriesType);
+    }
+
+    [TestMethod]
+    public void OriginalSize_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var stream = new ActivityStream
+        {
+            OriginalSize = 1500
+        };
+
+        // Act
+        var originalSize = stream.OriginalSize;
+
+        // Assert
+        Assert.AreEqual(1500, originalSize);
+    }
+
+    [TestMethod]
+    public void Resolution_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var stream = new ActivityStream
+        {
+            Resolution = "high"
+        };
+
+        // Act
+        var resolution = stream.Resolution;
+
+        // Assert
+        Assert.AreEqual("high", resolution);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithAllProperties_ShouldRetainValues()
+    {
+        // Arrange
+        var testData = new List<double> { 100.0, 105.5, 110.0, 108.5, 115.0 };
+        var stream = new ActivityStream
+        {
+            Type = "altitude",
+            SeriesType = "distance",
+            OriginalSize = 5000,
+            Resolution = "high",
+            Data = testData
+        };
+
+        // Act & Assert
+        Assert.AreEqual("altitude", stream.Type);
+        Assert.AreEqual("distance", stream.SeriesType);
+        Assert.AreEqual(5000, stream.OriginalSize);
+        Assert.AreEqual("high", stream.Resolution);
+        Assert.HasCount(5, stream.Data);
+        Assert.AreEqual(100.0, stream.Data[0]);
+        Assert.AreEqual(115.0, stream.Data[4]);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithTimeData_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var timeData = new List<double> { 0, 1, 2, 3, 4, 5 };
+        var stream = new ActivityStream
+        {
+            Type = "time",
+            SeriesType = "distance",
+            Data = timeData
+        };
+
+        // Act & Assert
+        Assert.AreEqual("time", stream.Type);
+        Assert.HasCount(6, stream.Data);
+        Assert.AreEqual(0, stream.Data[0]);
+        Assert.AreEqual(5, stream.Data[5]);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithDistanceData_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var distanceData = new List<double> { 0.0, 10.5, 25.3, 42.7, 58.9 };
+        var stream = new ActivityStream
+        {
+            Type = "distance",
+            SeriesType = "distance",
+            Data = distanceData
+        };
+
+        // Act & Assert
+        Assert.AreEqual("distance", stream.Type);
+        Assert.HasCount(5, stream.Data);
+        Assert.AreEqual(0.0, stream.Data[0]);
+        Assert.AreEqual(58.9, stream.Data[4]);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithHeartRateData_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var heartRateData = new List<double> { 65.0, 120.0, 145.0, 155.0, 165.0, 170.0, 160.0 };
+        var stream = new ActivityStream
+        {
+            Type = "heartrate",
+            SeriesType = "distance",
+            Data = heartRateData
+        };
+
+        // Act & Assert
+        Assert.AreEqual("heartrate", stream.Type);
+        Assert.HasCount(7, stream.Data);
+        Assert.AreEqual(65.0, stream.Data[0]);
+        Assert.AreEqual(160.0, stream.Data[6]);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithCadenceData_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var cadenceData = new List<double> { 0, 75, 80, 85, 90, 88 };
+        var stream = new ActivityStream
+        {
+            Type = "cadence",
+            SeriesType = "distance",
+            Data = cadenceData
+        };
+
+        // Act & Assert
+        Assert.AreEqual("cadence", stream.Type);
+        Assert.HasCount(6, stream.Data);
+        Assert.AreEqual(0, stream.Data[0]);
+        Assert.AreEqual(88, stream.Data[5]);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithWattsData_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var wattsData = new List<double> { 0, 150, 200, 250, 300, 280, 260 };
+        var stream = new ActivityStream
+        {
+            Type = "watts",
+            SeriesType = "distance",
+            Data = wattsData
+        };
+
+        // Act & Assert
+        Assert.AreEqual("watts", stream.Type);
+        Assert.HasCount(7, stream.Data);
+        Assert.AreEqual(0, stream.Data[0]);
+        Assert.AreEqual(260, stream.Data[6]);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithVelocitySmoothData_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var velocityData = new List<double> { 0.0, 2.5, 3.0, 3.5, 4.0, 3.8 };
+        var stream = new ActivityStream
+        {
+            Type = "velocity_smooth",
+            SeriesType = "distance",
+            Data = velocityData
+        };
+
+        // Act & Assert
+        Assert.AreEqual("velocity_smooth", stream.Type);
+        Assert.HasCount(6, stream.Data);
+        Assert.AreEqual(0.0, stream.Data[0]);
+        Assert.AreEqual(3.8, stream.Data[5]);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithGradeData_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var gradeData = new List<double> { 0.0, 1.5, 2.0, 3.5, -1.0, -2.5 };
+        var stream = new ActivityStream
+        {
+            Type = "grade_smooth",
+            SeriesType = "distance",
+            Data = gradeData
+        };
+
+        // Act & Assert
+        Assert.AreEqual("grade_smooth", stream.Type);
+        Assert.HasCount(6, stream.Data);
+        Assert.AreEqual(0.0, stream.Data[0]);
+        Assert.AreEqual(-2.5, stream.Data[5]);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithTemperatureData_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var tempData = new List<double> { 20.0, 20.5, 21.0, 21.5, 22.0 };
+        var stream = new ActivityStream
+        {
+            Type = "temp",
+            SeriesType = "distance",
+            Data = tempData
+        };
+
+        // Act & Assert
+        Assert.AreEqual("temp", stream.Type);
+        Assert.HasCount(5, stream.Data);
+        Assert.AreEqual(20.0, stream.Data[0]);
+        Assert.AreEqual(22.0, stream.Data[4]);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithMovingData_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var movingData = new List<double> { 1, 1, 1, 0, 0, 1, 1 };
+        var stream = new ActivityStream
+        {
+            Type = "moving",
+            SeriesType = "distance",
+            Data = movingData
+        };
+
+        // Act & Assert
+        Assert.AreEqual("moving", stream.Type);
+        Assert.HasCount(7, stream.Data);
+        Assert.AreEqual(1, stream.Data[0]);
+        Assert.AreEqual(0, stream.Data[3]);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithLargeDataSet_ShouldHandleCorrectly()
+    {
+        // Arrange
+        var largeData = Enumerable.Range(0, 10000).Select(i => (double)i).ToList();
+        var stream = new ActivityStream
+        {
+            Type = "distance",
+            SeriesType = "distance",
+            OriginalSize = 10000,
+            Data = largeData
+        };
+
+        // Act & Assert
+        Assert.AreEqual(10000, stream.OriginalSize);
+        Assert.HasCount(10000, stream.Data);
+        Assert.AreEqual(0, stream.Data[0]);
+        Assert.AreEqual(9999, stream.Data[9999]);
+    }
+
+    [TestMethod]
+    public void ActivityStream_InheritsFromStreamBase()
+    {
+        // Arrange
+        var stream = new ActivityStream();
+
+        // Act & Assert
+        Assert.IsInstanceOfType<StreamBase>(stream);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithNullType_ShouldBeAllowed()
+    {
+        // Arrange & Act
+        var stream = new ActivityStream
+        {
+            Type = null!
+        };
+
+        // Assert
+        Assert.IsNull(stream.Type);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithEmptyData_ShouldBeValid()
+    {
+        // Arrange
+        var stream = new ActivityStream
+        {
+            Type = "altitude",
+            SeriesType = "distance",
+            OriginalSize = 0,
+            Resolution = "high",
+            Data = []
+        };
+
+        // Act & Assert
+        Assert.AreEqual("altitude", stream.Type);
+        Assert.HasCount(0, stream.Data);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithNegativeValues_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var negativeData = new List<double> { -10.5, -20.3, -15.7, -5.2, 0.0 };
+        var stream = new ActivityStream
+        {
+            Type = "altitude",
+            Data = negativeData
+        };
+
+        // Act & Assert
+        Assert.HasCount(5, stream.Data);
+        Assert.AreEqual(-10.5, stream.Data[0]);
+        Assert.AreEqual(0.0, stream.Data[4]);
+    }
+
+    [TestMethod]
+    public void ActivityStream_DataProperty_CanBeReassigned()
+    {
+        // Arrange
+        var stream = new ActivityStream
+        {
+            Data = [1.0, 2.0, 3.0]
+        };
+
+        // Act
+        stream.Data = [4.0, 5.0, 6.0, 7.0];
+
+        // Assert
+        Assert.HasCount(4, stream.Data);
+        Assert.AreEqual(4.0, stream.Data[0]);
+        Assert.AreEqual(7.0, stream.Data[3]);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithZeroOriginalSize_ShouldBeValid()
+    {
+        // Arrange & Act
+        var stream = new ActivityStream
+        {
+            OriginalSize = 0,
+            Data = []
+        };
+
+        // Assert
+        Assert.AreEqual(0, stream.OriginalSize);
+        Assert.HasCount(0, stream.Data);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithHighResolution_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var stream = new ActivityStream
+        {
+            Type = "altitude",
+            Resolution = "high",
+            OriginalSize = 1000,
+            Data = [.. Enumerable.Range(0, 1000).Select(i => (double)i)]
+        };
+
+        // Act & Assert
+        Assert.AreEqual("high", stream.Resolution);
+        Assert.AreEqual(1000, stream.OriginalSize);
+        Assert.HasCount(1000, stream.Data);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithLowResolution_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var stream = new ActivityStream
+        {
+            Type = "altitude",
+            Resolution = "low",
+            OriginalSize = 5000,
+            Data = [.. Enumerable.Range(0, 500).Select(i => (double)i)]
+        };
+
+        // Act & Assert
+        Assert.AreEqual("low", stream.Resolution);
+        Assert.AreEqual(5000, stream.OriginalSize);
+        Assert.HasCount(500, stream.Data);
+    }
+
+    [TestMethod]
+    public void ActivityStream_WithMediumResolution_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var stream = new ActivityStream
+        {
+            Type = "altitude",
+            Resolution = "medium",
+            OriginalSize = 3000,
+            Data = [.. Enumerable.Range(0, 1000).Select(i => (double)i)]
+        };
+
+        // Act & Assert
+        Assert.AreEqual("medium", stream.Resolution);
+        Assert.AreEqual(3000, stream.OriginalSize);
+        Assert.HasCount(1000, stream.Data);
+    }
+}

--- a/src/Strava.Tests/Model/RouteStreamTests.cs
+++ b/src/Strava.Tests/Model/RouteStreamTests.cs
@@ -1,0 +1,551 @@
+﻿using Tudormobile.Strava.Model;
+
+namespace Strava.Tests.Model;
+
+[TestClass]
+public class RouteStreamTests
+{
+    [TestMethod]
+    public void Constructor_ShouldInitializeWithEmptyData()
+    {
+        // Arrange & Act
+        var stream = new RouteStream();
+
+        // Assert
+        Assert.IsNotNull(stream);
+        Assert.IsNotNull(stream.Data);
+        Assert.HasCount(0, stream.Data);
+    }
+
+    [TestMethod]
+    public void Data_ShouldBeInitializedAsEmptyList()
+    {
+        // Arrange
+        var stream = new RouteStream();
+
+        // Act
+        var data = stream.Data;
+
+        // Assert
+        Assert.IsNotNull(data);
+        Assert.HasCount(0, data);
+    }
+
+    [TestMethod]
+    public void Data_CanBeSetWithLatLngValues()
+    {
+        // Arrange
+        var stream = new RouteStream();
+        var testData = new List<LatLng>
+        {
+            new() { Latitude = 37.7749, Longitude = -122.4194 },
+            new() { Latitude = 37.7849, Longitude = -122.4294 },
+            new() { Latitude = 37.7949, Longitude = -122.4394 }
+        };
+
+        // Act
+        stream.Data = testData;
+
+        // Assert
+        Assert.AreEqual(testData, stream.Data);
+        Assert.HasCount(3, stream.Data);
+    }
+
+    [TestMethod]
+    public void Data_CanBeModifiedAfterInitialization()
+    {
+        // Arrange
+        var stream = new RouteStream();
+
+        // Act
+        stream.Data.Add(new LatLng { Latitude = 37.7749, Longitude = -122.4194 });
+        stream.Data.Add(new LatLng { Latitude = 37.7849, Longitude = -122.4294 });
+
+        // Assert
+        Assert.HasCount(2, stream.Data);
+        Assert.AreEqual(37.7749, stream.Data[0].Latitude, 0.0001);
+        Assert.AreEqual(-122.4194, stream.Data[0].Longitude, 0.0001);
+        Assert.AreEqual(37.7849, stream.Data[1].Latitude, 0.0001);
+        Assert.AreEqual(-122.4294, stream.Data[1].Longitude, 0.0001);
+    }
+
+    [TestMethod]
+    public void Type_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var stream = new RouteStream
+        {
+            Type = "latlng"
+        };
+
+        // Act
+        var type = stream.Type;
+
+        // Assert
+        Assert.AreEqual("latlng", type);
+    }
+
+    [TestMethod]
+    public void SeriesType_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var stream = new RouteStream
+        {
+            SeriesType = "distance"
+        };
+
+        // Act
+        var seriesType = stream.SeriesType;
+
+        // Assert
+        Assert.AreEqual("distance", seriesType);
+    }
+
+    [TestMethod]
+    public void OriginalSize_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var stream = new RouteStream
+        {
+            OriginalSize = 500
+        };
+
+        // Act
+        var originalSize = stream.OriginalSize;
+
+        // Assert
+        Assert.AreEqual(500, originalSize);
+    }
+
+    [TestMethod]
+    public void Resolution_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var stream = new RouteStream
+        {
+            Resolution = "high"
+        };
+
+        // Act
+        var resolution = stream.Resolution;
+
+        // Assert
+        Assert.AreEqual("high", resolution);
+    }
+
+    [TestMethod]
+    public void RouteStream_WithAllProperties_ShouldRetainValues()
+    {
+        // Arrange
+        var testData = new List<LatLng>
+        {
+            new() { Latitude = 37.7749, Longitude = -122.4194 },
+            new() { Latitude = 37.7849, Longitude = -122.4294 },
+            new() { Latitude = 37.7949, Longitude = -122.4394 }
+        };
+        var stream = new RouteStream
+        {
+            Type = "latlng",
+            SeriesType = "distance",
+            OriginalSize = 3000,
+            Resolution = "high",
+            Data = testData
+        };
+
+        // Act & Assert
+        Assert.AreEqual("latlng", stream.Type);
+        Assert.AreEqual("distance", stream.SeriesType);
+        Assert.AreEqual(3000, stream.OriginalSize);
+        Assert.AreEqual("high", stream.Resolution);
+        Assert.HasCount(3, stream.Data);
+        Assert.AreEqual(37.7749, stream.Data[0].Latitude, 0.0001);
+        Assert.AreEqual(-122.4194, stream.Data[0].Longitude, 0.0001);
+    }
+
+    [TestMethod]
+    public void RouteStream_WithRouteCoordinates_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var routePoints = new List<LatLng>
+        {
+            new() { Latitude = 40.7128, Longitude = -74.0060 },  // New York
+            new() { Latitude = 34.0522, Longitude = -118.2437 }, // Los Angeles
+            new() { Latitude = 41.8781, Longitude = -87.6298 }   // Chicago
+        };
+        var stream = new RouteStream
+        {
+            Type = "latlng",
+            SeriesType = "distance",
+            Data = routePoints
+        };
+
+        // Act & Assert
+        Assert.AreEqual("latlng", stream.Type);
+        Assert.HasCount(3, stream.Data);
+        Assert.AreEqual(40.7128, stream.Data[0].Latitude, 0.0001);
+        Assert.AreEqual(-74.0060, stream.Data[0].Longitude, 0.0001);
+        Assert.AreEqual(34.0522, stream.Data[1].Latitude, 0.0001);
+        Assert.AreEqual(-118.2437, stream.Data[1].Longitude, 0.0001);
+    }
+
+    [TestMethod]
+    public void RouteStream_WithTupleInitialization_ShouldWork()
+    {
+        // Arrange
+        var stream = new RouteStream();
+
+        // Act
+        stream.Data.Add((37.7749, -122.4194));
+        stream.Data.Add((37.7849, -122.4294));
+
+        // Assert
+        Assert.HasCount(2, stream.Data);
+        Assert.AreEqual(37.7749, stream.Data[0].Latitude, 0.0001);
+        Assert.AreEqual(-122.4194, stream.Data[0].Longitude, 0.0001);
+    }
+
+    [TestMethod]
+    public void RouteStream_WithNegativeCoordinates_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var negativeCoords = new List<LatLng>
+        {
+            new() { Latitude = -33.8688, Longitude = 151.2093 },  // Sydney
+            new() { Latitude = -23.5505, Longitude = -46.6333 },  // São Paulo
+            new() { Latitude = -34.6037, Longitude = -58.3816 }   // Buenos Aires
+        };
+        var stream = new RouteStream
+        {
+            Type = "latlng",
+            Data = negativeCoords
+        };
+
+        // Act & Assert
+        Assert.HasCount(3, stream.Data);
+        Assert.AreEqual(-33.8688, stream.Data[0].Latitude, 0.0001);
+        Assert.AreEqual(151.2093, stream.Data[0].Longitude, 0.0001);
+        Assert.AreEqual(-23.5505, stream.Data[1].Latitude, 0.0001);
+        Assert.AreEqual(-46.6333, stream.Data[1].Longitude, 0.0001);
+    }
+
+    [TestMethod]
+    public void RouteStream_WithEquatorCoordinates_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var equatorCoords = new List<LatLng>
+        {
+            new() { Latitude = 0.0, Longitude = 0.0 },
+            new() { Latitude = 0.0, Longitude = 180.0 },
+            new() { Latitude = 0.0, Longitude = -180.0 }
+        };
+        var stream = new RouteStream
+        {
+            Type = "latlng",
+            Data = equatorCoords
+        };
+
+        // Act & Assert
+        Assert.HasCount(3, stream.Data);
+        Assert.AreEqual(0.0, stream.Data[0].Latitude);
+        Assert.AreEqual(0.0, stream.Data[0].Longitude);
+        Assert.AreEqual(0.0, stream.Data[1].Latitude);
+        Assert.AreEqual(180.0, stream.Data[1].Longitude);
+    }
+
+    [TestMethod]
+    public void RouteStream_WithPolarCoordinates_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var polarCoords = new List<LatLng>
+        {
+            new() { Latitude = 90.0, Longitude = 0.0 },   // North Pole
+            new() { Latitude = -90.0, Longitude = 0.0 }   // South Pole
+        };
+        var stream = new RouteStream
+        {
+            Type = "latlng",
+            Data = polarCoords
+        };
+
+        // Act & Assert
+        Assert.HasCount(2, stream.Data);
+        Assert.AreEqual(90.0, stream.Data[0].Latitude);
+        Assert.AreEqual(-90.0, stream.Data[1].Latitude);
+    }
+
+    [TestMethod]
+    public void RouteStream_WithLargeDataSet_ShouldHandleCorrectly()
+    {
+        // Arrange
+        var largeData = Enumerable.Range(0, 5000)
+            .Select(i => new LatLng { Latitude = i * 0.001, Longitude = i * -0.001 })
+            .ToList();
+        var stream = new RouteStream
+        {
+            Type = "latlng",
+            SeriesType = "distance",
+            OriginalSize = 5000,
+            Data = largeData
+        };
+
+        // Act & Assert
+        Assert.AreEqual(5000, stream.OriginalSize);
+        Assert.HasCount(5000, stream.Data);
+        Assert.AreEqual(0.0, stream.Data[0].Latitude);
+        Assert.AreEqual(0.0, stream.Data[0].Longitude);
+        Assert.AreEqual(4.999, stream.Data[4999].Latitude, 0.0001);
+        Assert.AreEqual(-4.999, stream.Data[4999].Longitude, 0.0001);
+    }
+
+    [TestMethod]
+    public void RouteStream_InheritsFromStreamBase()
+    {
+        // Arrange
+        var stream = new RouteStream();
+
+        // Act & Assert
+        Assert.IsInstanceOfType<StreamBase>(stream);
+    }
+
+    [TestMethod]
+    public void RouteStream_WithEmptyData_ShouldBeValid()
+    {
+        // Arrange
+        var stream = new RouteStream
+        {
+            Type = "latlng",
+            SeriesType = "distance",
+            OriginalSize = 0,
+            Resolution = "high",
+            Data = []
+        };
+
+        // Act & Assert
+        Assert.AreEqual("latlng", stream.Type);
+        Assert.HasCount(0, stream.Data);
+    }
+
+    [TestMethod]
+    public void RouteStream_DataProperty_CanBeReassigned()
+    {
+        // Arrange
+        var stream = new RouteStream
+        {
+            Data = [
+                new LatLng { Latitude = 1.0, Longitude = 1.0 },
+                new LatLng { Latitude = 2.0, Longitude = 2.0 }
+            ]
+        };
+
+        // Act
+        stream.Data = [
+            new LatLng { Latitude = 3.0, Longitude = 3.0 },
+            new LatLng { Latitude = 4.0, Longitude = 4.0 },
+            new LatLng { Latitude = 5.0, Longitude = 5.0 }
+        ];
+
+        // Assert
+        Assert.HasCount(3, stream.Data);
+        Assert.AreEqual(3.0, stream.Data[0].Latitude);
+        Assert.AreEqual(5.0, stream.Data[2].Latitude);
+    }
+
+    [TestMethod]
+    public void RouteStream_WithHighResolution_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var stream = new RouteStream
+        {
+            Type = "latlng",
+            Resolution = "high",
+            OriginalSize = 1000,
+            Data = [.. Enumerable.Range(0, 1000).Select(i => new LatLng { Latitude = 40.0 + i * 0.0001, Longitude = -74.0 + i * 0.0001 })]
+        };
+
+        // Act & Assert
+        Assert.AreEqual("high", stream.Resolution);
+        Assert.AreEqual(1000, stream.OriginalSize);
+        Assert.HasCount(1000, stream.Data);
+    }
+
+    [TestMethod]
+    public void RouteStream_WithLowResolution_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var stream = new RouteStream
+        {
+            Type = "latlng",
+            Resolution = "low",
+            OriginalSize = 5000,
+            Data = [.. Enumerable.Range(0, 500).Select(i => new LatLng { Latitude = 40.0 + i * 0.001, Longitude = -74.0 + i * 0.001 })]
+        };
+
+        // Act & Assert
+        Assert.AreEqual("low", stream.Resolution);
+        Assert.AreEqual(5000, stream.OriginalSize);
+        Assert.HasCount(500, stream.Data);
+    }
+
+    [TestMethod]
+    public void RouteStream_WithMediumResolution_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var stream = new RouteStream
+        {
+            Type = "latlng",
+            Resolution = "medium",
+            OriginalSize = 3000,
+            Data = [.. Enumerable.Range(0, 1000).Select(i => new LatLng { Latitude = 40.0 + i * 0.0005, Longitude = -74.0 + i * 0.0005 })]
+        };
+
+        // Act & Assert
+        Assert.AreEqual("medium", stream.Resolution);
+        Assert.AreEqual(3000, stream.OriginalSize);
+        Assert.HasCount(1000, stream.Data);
+    }
+
+    [TestMethod]
+    public void RouteStream_WithAltitudeType_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var stream = new RouteStream
+        {
+            Type = "altitude",
+            SeriesType = "distance",
+            Data = [
+                new LatLng { Latitude = 37.7749, Longitude = -122.4194 },
+                new LatLng { Latitude = 37.7849, Longitude = -122.4294 }
+            ]
+        };
+
+        // Act & Assert
+        Assert.AreEqual("altitude", stream.Type);
+        Assert.HasCount(2, stream.Data);
+    }
+
+    [TestMethod]
+    public void RouteStream_WithDistanceType_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var stream = new RouteStream
+        {
+            Type = "distance",
+            SeriesType = "distance",
+            Data = [
+                new LatLng { Latitude = 37.7749, Longitude = -122.4194 },
+                new LatLng { Latitude = 37.7849, Longitude = -122.4294 }
+            ]
+        };
+
+        // Act & Assert
+        Assert.AreEqual("distance", stream.Type);
+        Assert.HasCount(2, stream.Data);
+    }
+
+    [TestMethod]
+    public void RouteStream_WithMultipleCoordinatePairs_ShouldAccessByIndex()
+    {
+        // Arrange
+        var stream = new RouteStream
+        {
+            Data = [
+                new LatLng { Latitude = 10.0, Longitude = 20.0 },
+                new LatLng { Latitude = 30.0, Longitude = 40.0 },
+                new LatLng { Latitude = 50.0, Longitude = 60.0 }
+            ]
+        };
+
+        // Act
+        var first = stream.Data[0];
+        var second = stream.Data[1];
+        var third = stream.Data[2];
+
+        // Assert
+        Assert.AreEqual(10.0, first.Latitude);
+        Assert.AreEqual(20.0, first.Longitude);
+        Assert.AreEqual(30.0, second.Latitude);
+        Assert.AreEqual(40.0, second.Longitude);
+        Assert.AreEqual(50.0, third.Latitude);
+        Assert.AreEqual(60.0, third.Longitude);
+    }
+
+    [TestMethod]
+    public void RouteStream_WithPreciseCoordinates_ShouldMaintainPrecision()
+    {
+        // Arrange
+        var preciseCoords = new List<LatLng>
+        {
+            new() { Latitude = 37.7749295, Longitude = -122.4194155 },
+            new() { Latitude = 37.7849295, Longitude = -122.4294155 }
+        };
+        var stream = new RouteStream
+        {
+            Type = "latlng",
+            Data = preciseCoords
+        };
+
+        // Act & Assert
+        Assert.AreEqual(37.7749295, stream.Data[0].Latitude, 0.0000001);
+        Assert.AreEqual(-122.4194155, stream.Data[0].Longitude, 0.0000001);
+        Assert.AreEqual(37.7849295, stream.Data[1].Latitude, 0.0000001);
+        Assert.AreEqual(-122.4294155, stream.Data[1].Longitude, 0.0000001);
+    }
+
+    [TestMethod]
+    public void RouteStream_WithZeroCoordinates_ShouldBeValid()
+    {
+        // Arrange
+        var stream = new RouteStream
+        {
+            Type = "latlng",
+            Data = [
+                new LatLng { Latitude = 0.0, Longitude = 0.0 }
+            ]
+        };
+
+        // Act & Assert
+        Assert.HasCount(1, stream.Data);
+        Assert.AreEqual(0.0, stream.Data[0].Latitude);
+        Assert.AreEqual(0.0, stream.Data[0].Longitude);
+    }
+
+    [TestMethod]
+    public void RouteStream_DataList_CanBeCleared()
+    {
+        // Arrange
+        var stream = new RouteStream
+        {
+            Data = [
+                new LatLng { Latitude = 1.0, Longitude = 1.0 },
+                new LatLng { Latitude = 2.0, Longitude = 2.0 }
+            ]
+        };
+
+        // Act
+        stream.Data.Clear();
+
+        // Assert
+        Assert.HasCount(0, stream.Data);
+    }
+
+    [TestMethod]
+    public void RouteStream_WithInternationalDateLine_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var dateLine = new List<LatLng>
+        {
+            new() { Latitude = 0.0, Longitude = 179.0 },
+            new() { Latitude = 0.0, Longitude = -179.0 }
+        };
+        var stream = new RouteStream
+        {
+            Type = "latlng",
+            Data = dateLine
+        };
+
+        // Act & Assert
+        Assert.HasCount(2, stream.Data);
+        Assert.AreEqual(179.0, stream.Data[0].Longitude);
+        Assert.AreEqual(-179.0, stream.Data[1].Longitude);
+    }
+}

--- a/src/Strava.Tests/Model/SegmentEffortStreamTests.cs
+++ b/src/Strava.Tests/Model/SegmentEffortStreamTests.cs
@@ -1,0 +1,127 @@
+﻿using Tudormobile.Strava.Model;
+
+namespace Strava.Tests.Model;
+
+[TestClass]
+public class SegmentEffortStreamTests
+{
+    [TestMethod]
+    public void Constructor_ShouldInitializeWithEmptyData()
+    {
+        // Arrange & Act
+        var stream = new SegmentEffortStream();
+
+        // Assert
+        Assert.IsNotNull(stream);
+        Assert.IsNotNull(stream.Data);
+        Assert.HasCount(0, stream.Data);
+    }
+
+    [TestMethod]
+    public void Data_CanBeSetWithValues()
+    {
+        // Arrange
+        var stream = new SegmentEffortStream();
+        var testData = new List<double> { 1.0, 2.0, 3.0 };
+
+        // Act
+        stream.Data = testData;
+
+        // Assert
+        Assert.AreEqual(testData, stream.Data);
+        Assert.HasCount(3, stream.Data);
+    }
+
+    [TestMethod]
+    public void Data_CanBeModifiedAfterInitialization()
+    {
+        // Arrange
+        var stream = new SegmentEffortStream();
+
+        // Act
+        stream.Data.Add(10.5);
+        stream.Data.Add(20.5);
+
+        // Assert
+        Assert.HasCount(2, stream.Data);
+        Assert.AreEqual(10.5, stream.Data[0]);
+        Assert.AreEqual(20.5, stream.Data[1]);
+    }
+
+    [TestMethod]
+    public void Type_CanBeSetAndRetrieved()
+    {
+        // Arrange & Act
+        var stream = new SegmentEffortStream
+        {
+            Type = "altitude"
+        };
+
+        // Assert
+        Assert.AreEqual("altitude", stream.Type);
+    }
+
+    [TestMethod]
+    public void SegmentEffortStream_WithAllProperties_ShouldRetainValues()
+    {
+        // Arrange
+        var testData = new List<double> { 100.0, 105.5, 110.0 };
+        var stream = new SegmentEffortStream
+        {
+            Type = "altitude",
+            SeriesType = "distance",
+            OriginalSize = 1000,
+            Resolution = "high",
+            Data = testData
+        };
+
+        // Act & Assert
+        Assert.AreEqual("altitude", stream.Type);
+        Assert.AreEqual("distance", stream.SeriesType);
+        Assert.AreEqual(1000, stream.OriginalSize);
+        Assert.AreEqual("high", stream.Resolution);
+        Assert.HasCount(3, stream.Data);
+    }
+
+    [TestMethod]
+    public void SegmentEffortStream_InheritsFromStreamBase()
+    {
+        // Arrange
+        var stream = new SegmentEffortStream();
+
+        // Act & Assert
+        Assert.IsInstanceOfType<StreamBase>(stream);
+    }
+
+    [TestMethod]
+    public void SegmentEffortStream_WithHeartRateData_ShouldStoreCorrectly()
+    {
+        // Arrange
+        var heartRateData = new List<double> { 120.0, 145.0, 165.0 };
+        var stream = new SegmentEffortStream
+        {
+            Type = "heartrate",
+            Data = heartRateData
+        };
+
+        // Act & Assert
+        Assert.AreEqual("heartrate", stream.Type);
+        Assert.HasCount(3, stream.Data);
+        Assert.AreEqual(120.0, stream.Data[0]);
+    }
+
+    [TestMethod]
+    public void SegmentEffortStream_WithEmptyData_ShouldBeValid()
+    {
+        // Arrange
+        var stream = new SegmentEffortStream
+        {
+            Type = "watts",
+            Data = []
+        };
+
+        // Act & Assert
+        Assert.AreEqual("watts", stream.Type);
+        Assert.HasCount(0, stream.Data);
+    }
+}

--- a/src/Strava.Tests/Model/SegmentStreamTests.cs
+++ b/src/Strava.Tests/Model/SegmentStreamTests.cs
@@ -1,0 +1,134 @@
+﻿using Tudormobile.Strava;
+using Tudormobile.Strava.Model;
+
+namespace Strava.Tests.Model;
+
+[TestClass]
+public class SegmentStreamTests
+{
+    [TestMethod]
+    public void Constructor_ShouldInitializeWithEmptyData()
+    {
+        // Arrange & Act
+        var stream = new SegmentStream();
+
+        // Assert
+        Assert.IsNotNull(stream);
+        Assert.IsNotNull(stream.Data);
+        Assert.HasCount(0, stream.Data);
+    }
+
+    [TestMethod]
+    public void Data_CanBeSetWithLatLngValues()
+    {
+        // Arrange
+        var stream = new SegmentStream
+        {
+            // Act
+            Data = [[37.7749, -122.4194]]
+        };
+
+        // Assert
+        Assert.AreEqual(37.7749, stream.Points[0].Latitude, 0.0001);
+        Assert.AreEqual(-122.4194, stream.Points[0].Longitude, 0.0001);
+        Assert.HasCount(1, stream.Data);
+    }
+
+    [TestMethod]
+    public void Data_CanBeModifiedAfterInitialization()
+    {
+        // Arrange
+        var stream = new SegmentStream();
+
+        // Act
+        stream.Data.Add([37.7749, -122.4294]);
+
+        // Assert
+        Assert.HasCount(1, stream.Data);
+        Assert.AreEqual(37.7749, stream.Points[0].Latitude, 0.0001);
+        Assert.AreEqual(-122.4294, stream.Points[0].Longitude, 0.0001);
+    }
+
+    [TestMethod]
+    public void SegmentStream_WithAllProperties_ShouldRetainValues()
+    {
+        // Arrange
+        List<double> testData = [37.7749, -122.4194];
+        var stream = new SegmentStream
+        {
+            Type = "latlng",
+            SeriesType = "distance",
+            OriginalSize = 1000,
+            Resolution = "high",
+            Data = [testData]
+        };
+
+        // Act & Assert
+        Assert.AreEqual("latlng", stream.Type);
+        Assert.AreEqual("distance", stream.SeriesType);
+        Assert.AreEqual(1000, stream.OriginalSize);
+        Assert.AreEqual("high", stream.Resolution);
+        Assert.HasCount(1, stream.Data);
+    }
+
+    [TestMethod]
+    public void SegmentStream_InheritsFromStreamBase()
+    {
+        // Arrange
+        var stream = new SegmentStream();
+
+        // Act & Assert
+        Assert.IsInstanceOfType<StreamBase>(stream);
+    }
+
+    [TestMethod]
+    public void SegmentStream_WithEmptyData_ShouldBeValid()
+    {
+        // Arrange
+        var stream = new SegmentStream
+        {
+            Type = "latlng",
+            Data = []
+        };
+
+        // Act & Assert
+        Assert.AreEqual("latlng", stream.Type);
+        Assert.HasCount(0, stream.Data);
+    }
+
+    [TestMethod]
+    public void SegmentStream_CanDeserializeFromJson()
+    {
+        // Arrange 
+        var json = @"{
+            ""type"": ""latlng"",
+            ""data"": [
+              [
+                37.833112,
+                -122.483436
+              ],
+              [
+                37.832964,
+                -122.483406
+              ]
+            ],
+            ""series_type"": ""distance"",
+            ""original_size"": 2,
+            ""resolution"": ""high""
+        }";
+
+        // Act
+        var success = StravaSerializer.TryDeserialize<SegmentStream>(json, out var stream);
+
+        // Assert
+        Assert.IsTrue(success);
+        Assert.IsNotNull(stream);
+        Assert.AreEqual("latlng", stream.Type);
+        Assert.AreEqual("distance", stream.SeriesType);
+        Assert.AreEqual(2, stream.OriginalSize);
+        Assert.AreEqual("high", stream.Resolution);
+        Assert.IsNotNull(stream.Data);
+        Assert.HasCount(2, stream.Data);
+        Assert.HasCount(2, stream.Points);
+    }
+}

--- a/src/Strava.Tests/Model/StreamBaseTests.cs
+++ b/src/Strava.Tests/Model/StreamBaseTests.cs
@@ -1,0 +1,178 @@
+﻿using Tudormobile.Strava.Model;
+
+namespace Strava.Tests.Model;
+
+[TestClass]
+public class StreamBaseTests
+{
+    [TestMethod]
+    public void Constructor_ShouldInitializeProperties()
+    {
+        // Arrange & Act
+        var stream = new StreamBase();
+
+        // Assert
+        Assert.IsNotNull(stream);
+    }
+
+    [TestMethod]
+    public void Type_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var stream = new StreamBase
+        {
+            Type = "altitude"
+        };
+
+        // Act
+        var type = stream.Type;
+
+        // Assert
+        Assert.AreEqual("altitude", type);
+    }
+
+    [TestMethod]
+    public void SeriesType_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var stream = new StreamBase
+        {
+            SeriesType = "distance"
+        };
+
+        // Act
+        var seriesType = stream.SeriesType;
+
+        // Assert
+        Assert.AreEqual("distance", seriesType);
+    }
+
+    [TestMethod]
+    public void OriginalSize_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var stream = new StreamBase
+        {
+            OriginalSize = 1500
+        };
+
+        // Act
+        var originalSize = stream.OriginalSize;
+
+        // Assert
+        Assert.AreEqual(1500, originalSize);
+    }
+
+    [TestMethod]
+    public void Resolution_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var stream = new StreamBase
+        {
+            Resolution = "high"
+        };
+
+        // Act
+        var resolution = stream.Resolution;
+
+        // Assert
+        Assert.AreEqual("high", resolution);
+    }
+
+    [TestMethod]
+    public void StreamBase_WithAllProperties_ShouldRetainValues()
+    {
+        // Arrange
+        var stream = new StreamBase
+        {
+            Type = "heartrate",
+            SeriesType = "time",
+            OriginalSize = 3000,
+            Resolution = "medium"
+        };
+
+        // Act & Assert
+        Assert.AreEqual("heartrate", stream.Type);
+        Assert.AreEqual("time", stream.SeriesType);
+        Assert.AreEqual(3000, stream.OriginalSize);
+        Assert.AreEqual("medium", stream.Resolution);
+    }
+
+    [TestMethod]
+    public void Type_WithVariousStreamTypes_ShouldStore()
+    {
+        // Arrange & Act
+        var streams = new[]
+        {
+            new StreamBase { Type = "time" },
+            new StreamBase { Type = "latlng" },
+            new StreamBase { Type = "distance" },
+            new StreamBase { Type = "altitude" },
+            new StreamBase { Type = "velocity_smooth" },
+            new StreamBase { Type = "heartrate" },
+            new StreamBase { Type = "cadence" },
+            new StreamBase { Type = "watts" },
+            new StreamBase { Type = "temp" },
+            new StreamBase { Type = "moving" },
+            new StreamBase { Type = "grade_smooth" }
+        };
+
+        // Assert
+        Assert.AreEqual("time", streams[0].Type);
+        Assert.AreEqual("latlng", streams[1].Type);
+        Assert.AreEqual("distance", streams[2].Type);
+        Assert.AreEqual("altitude", streams[3].Type);
+        Assert.AreEqual("velocity_smooth", streams[4].Type);
+        Assert.AreEqual("heartrate", streams[5].Type);
+        Assert.AreEqual("cadence", streams[6].Type);
+        Assert.AreEqual("watts", streams[7].Type);
+        Assert.AreEqual("temp", streams[8].Type);
+        Assert.AreEqual("moving", streams[9].Type);
+        Assert.AreEqual("grade_smooth", streams[10].Type);
+    }
+
+    [TestMethod]
+    public void OriginalSize_WithZeroValue_ShouldBeValid()
+    {
+        // Arrange & Act
+        var stream = new StreamBase
+        {
+            OriginalSize = 0
+        };
+
+        // Assert
+        Assert.AreEqual(0, stream.OriginalSize);
+    }
+
+    [TestMethod]
+    public void Resolution_WithVariousResolutions_ShouldStore()
+    {
+        // Arrange & Act
+        var lowRes = new StreamBase { Resolution = "low" };
+        var mediumRes = new StreamBase { Resolution = "medium" };
+        var highRes = new StreamBase { Resolution = "high" };
+
+        // Assert
+        Assert.AreEqual("low", lowRes.Resolution);
+        Assert.AreEqual("medium", mediumRes.Resolution);
+        Assert.AreEqual("high", highRes.Resolution);
+    }
+
+    [TestMethod]
+    public void StreamBase_WithNullProperties_ShouldBeAllowed()
+    {
+        // Arrange & Act
+        var stream = new StreamBase
+        {
+            Type = null!,
+            SeriesType = null!,
+            Resolution = null!
+        };
+
+        // Assert
+        Assert.IsNull(stream.Type);
+        Assert.IsNull(stream.SeriesType);
+        Assert.IsNull(stream.Resolution);
+        Assert.AreEqual(0, stream.OriginalSize);
+    }
+}

--- a/src/Strava.Tests/Model/UploadTests.cs
+++ b/src/Strava.Tests/Model/UploadTests.cs
@@ -1,0 +1,203 @@
+﻿using Tudormobile.Strava.Model;
+
+namespace Strava.Tests.Model;
+
+[TestClass]
+public class UploadTests
+{
+    [TestMethod]
+    public void Constructor_ShouldInitialize()
+    {
+        // Arrange & Act
+        var upload = new Upload();
+
+        // Assert
+        Assert.IsNotNull(upload);
+        Assert.AreEqual(0, upload.Id);
+        Assert.AreEqual(0, upload.ActivityId);
+    }
+
+    [TestMethod]
+    public void Id_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var upload = new Upload
+        {
+            Id = 123456789
+        };
+
+        // Act
+        var id = upload.Id;
+
+        // Assert
+        Assert.AreEqual(123456789, id);
+    }
+
+    [TestMethod]
+    public void ActivityId_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var upload = new Upload
+        {
+            ActivityId = 987654321
+        };
+
+        // Act
+        var activityId = upload.ActivityId;
+
+        // Assert
+        Assert.AreEqual(987654321, activityId);
+    }
+
+    [TestMethod]
+    public void IdStr_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var upload = new Upload
+        {
+            IdStr = "123456789"
+        };
+
+        // Act
+        var idStr = upload.IdStr;
+
+        // Assert
+        Assert.AreEqual("123456789", idStr);
+    }
+
+    [TestMethod]
+    public void ExternalId_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var upload = new Upload
+        {
+            ExternalId = "external_123.gpx"
+        };
+
+        // Act
+        var externalId = upload.ExternalId;
+
+        // Assert
+        Assert.AreEqual("external_123.gpx", externalId);
+    }
+
+    [TestMethod]
+    public void Error_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var upload = new Upload
+        {
+            Error = "Invalid file format"
+        };
+
+        // Act
+        var error = upload.Error;
+
+        // Assert
+        Assert.AreEqual("Invalid file format", error);
+    }
+
+    [TestMethod]
+    public void Status_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var upload = new Upload
+        {
+            Status = "Your activity is ready."
+        };
+
+        // Act
+        var status = upload.Status;
+
+        // Assert
+        Assert.AreEqual("Your activity is ready.", status);
+    }
+
+    [TestMethod]
+    public void Upload_WithAllProperties_ShouldRetainValues()
+    {
+        // Arrange
+        var upload = new Upload
+        {
+            Id = 123456789,
+            ActivityId = 987654321,
+            IdStr = "123456789",
+            ExternalId = "ride_2023.tcx",
+            Error = null!,
+            Status = "Your activity is ready."
+        };
+
+        // Act & Assert
+        Assert.AreEqual(123456789, upload.Id);
+        Assert.AreEqual(987654321, upload.ActivityId);
+        Assert.AreEqual("123456789", upload.IdStr);
+        Assert.AreEqual("ride_2023.tcx", upload.ExternalId);
+        Assert.IsNull(upload.Error);
+        Assert.AreEqual("Your activity is ready.", upload.Status);
+    }
+
+    [TestMethod]
+    public void Status_WithProcessingStatus_ShouldStore()
+    {
+        // Arrange & Act
+        var upload = new Upload
+        {
+            Status = "Your activity is still being processed."
+        };
+
+        // Assert
+        Assert.AreEqual("Your activity is still being processed.", upload.Status);
+    }
+
+    [TestMethod]
+    public void Status_WithErrorStatus_ShouldStoreWithError()
+    {
+        // Arrange & Act
+        var upload = new Upload
+        {
+            Status = "There was an error processing your activity.",
+            Error = "Duplicate activity detected"
+        };
+
+        // Assert
+        Assert.AreEqual("There was an error processing your activity.", upload.Status);
+        Assert.AreEqual("Duplicate activity detected", upload.Error);
+    }
+
+    [TestMethod]
+    public void Upload_WithNullStringProperties_ShouldBeAllowed()
+    {
+        // Arrange & Act
+        var upload = new Upload
+        {
+            Id = 123,
+            IdStr = null!,
+            ExternalId = null!,
+            Error = null!,
+            Status = null!
+        };
+
+        // Assert
+        Assert.AreEqual(123, upload.Id);
+        Assert.IsNull(upload.IdStr);
+        Assert.IsNull(upload.ExternalId);
+        Assert.IsNull(upload.Error);
+        Assert.IsNull(upload.Status);
+    }
+
+    [TestMethod]
+    public void Upload_WithZeroActivityId_ShouldBeValid()
+    {
+        // Arrange & Act
+        var upload = new Upload
+        {
+            Id = 123456789,
+            ActivityId = 0,
+            Status = "Your activity is still being processed."
+        };
+
+        // Assert
+        Assert.AreEqual(0, upload.ActivityId);
+        Assert.AreEqual(123456789, upload.Id);
+    }
+}

--- a/src/Strava/Api/ApiExtensions.cs
+++ b/src/Strava/Api/ApiExtensions.cs
@@ -51,13 +51,13 @@ public static class ApiExtensions
     /// Creates or returns the existing StreamApi interface.
     /// </summary>
     /// <returns>Interface for accessing the Strava Streams API.</returns>
-    public static IStreamsApi StreamApi(this StravaSession session) => throw new NotImplementedException("Streams API not implemented yet.");
+    public static IStreamsApi StreamsApi(this StravaSession session) => (IStreamsApi)session.StravaApi();
 
     /// <summary>
     /// Creates or returns the existing UploadsApi interface.
     /// </summary>
     /// <returns>Interface for accessing the Strava Uploads API.</returns>
-    public static IUploadsApi UploadsApi(this StravaSession session) => throw new NotImplementedException("Uploads API not implemented yet.");
+    public static IUploadsApi UploadsApi(this StravaSession session) => (IUploadsApi)session.StravaApi();
 
     /// <summary>
     /// Appends query parameters to a URI string.

--- a/src/Strava/Api/IStreamsApi.cs
+++ b/src/Strava/Api/IStreamsApi.cs
@@ -1,8 +1,73 @@
-﻿namespace Tudormobile.Strava.Api;
+﻿using Tudormobile.Strava.Model;
+
+namespace Tudormobile.Strava.Api;
 
 /// <summary>
 /// Strava V3 Streams API Interface.
 /// </summary>
-public interface IStreamsApi : IStravaApi
+public interface IStreamsApi
 {
+    /// <summary>
+    /// Asynchronously retrieves a list of activity streams for the specified resource and activity types.
+    /// </summary>
+    /// <param name="id">The unique identifier of the resource for which to retrieve activity streams.</param>
+    /// <param name="types">A collection of activity stream types to include in the result. Each type specifies a category of activity data to
+    /// retrieve. Cannot be null or empty.</param>
+    /// <param name="keysByType">true to group the returned activity streams by type; otherwise, false to return a flat list.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an ApiResult with a list of
+    /// ActivityStream objects matching the specified types. The list may be empty if no streams are found.</returns>
+    Task<ApiResult<List<ActivityStream>>> GetActivityStreamsAsync(long id, IEnumerable<String> types, bool keysByType = true, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously retrieves the requested data streams for a specific segment effort.
+    /// </summary>
+    /// <remarks>If a requested stream type is not available for the specified segment effort, it will be
+    /// omitted from the result. The method supports cancellation via the provided token.</remarks>
+    /// <param name="id">The identifier of the segment effort for which to retrieve streams.</param>
+    /// <param name="types">A collection of stream types to retrieve. Each type specifies a particular data stream, such as time, distance, or
+    /// heart rate.</param>
+    /// <param name="keysByType">true to return the result as a dictionary keyed by stream type; otherwise, false to return a list of streams in
+    /// the order requested.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an ApiResult with a list of
+    /// SegmentEffortStream objects corresponding to the requested stream types.</returns>
+    Task<ApiResult<List<SegmentEffortStream>>> GetSegmentEffortStreamsAsync(long id, IEnumerable<String> types, bool keysByType = true, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously retrieves a list of segment streams for the specified segment and stream types.
+    /// </summary>
+    /// <param name="id">The unique identifier of the segment for which to retrieve streams.</param>
+    /// <param name="types">A collection of stream type names to filter the results. Only streams matching these types are returned.</param>
+    /// <param name="keysByType">true to group the returned streams by type; otherwise, false to return a flat list.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an ApiResult with a list of
+    /// SegmentStream objects matching the specified criteria.</returns>
+    Task<ApiResult<SegmentStreamCollection>> GetSegmentStreamsAsync(long id, IEnumerable<String> types, bool keysByType = true, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously retrieves all route streams associated with the specified route identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier of the route for which to retrieve streams.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an <see cref="ApiResult{T}"/> with a
+    /// list of <see cref="RouteStream"/> objects for the specified route. If no streams are found, the list will be
+    /// empty.</returns>
+    Task<ApiResult<List<RouteStream>>> GetRouteStreamsAsync(long id, CancellationToken cancellationToken = default);
+}
+
+internal partial class StravaApiImpl
+{
+    /// <inheritdoc/>
+    public Task<ApiResult<List<ActivityStream>>> GetActivityStreamsAsync(long id, IEnumerable<string> types, bool keysByType = true, CancellationToken cancellationToken = default)
+        => GetApiResultAsync<List<ActivityStream>>(ApiExtensions.AddQueryToUriString($"/activities/{id}/streams", [("keys", types.ToArray()), ("keys_by_type", keysByType.ToString())]), cancellationToken);
+    /// <inheritdoc/>
+    public Task<ApiResult<List<SegmentEffortStream>>> GetSegmentEffortStreamsAsync(long id, IEnumerable<string> types, bool keysByType = true, CancellationToken cancellationToken = default)
+        => GetApiResultAsync<List<SegmentEffortStream>>(ApiExtensions.AddQueryToUriString($"/segment_efforts/{id}/streams", [("keys", types.ToArray()), ("keys_by_type", keysByType.ToString())]), cancellationToken);
+    /// <inheritdoc/>
+    public Task<ApiResult<SegmentStreamCollection>> GetSegmentStreamsAsync(long id, IEnumerable<string> types, bool keysByType = true, CancellationToken cancellationToken = default)
+        => GetApiResultAsync<SegmentStreamCollection>(ApiExtensions.AddQueryToUriString($"/segments/{id}/streams", [("keys", types.ToArray()), ("keys_by_type", keysByType.ToString())]), cancellationToken);
+    /// <inheritdoc/>
+    public Task<ApiResult<List<RouteStream>>> GetRouteStreamsAsync(long id, CancellationToken cancellationToken = default)
+        => GetApiResultAsync<List<RouteStream>>($"/routes/{id}/streams", cancellationToken);
 }

--- a/src/Strava/Api/IUploadsApi.cs
+++ b/src/Strava/Api/IUploadsApi.cs
@@ -1,8 +1,55 @@
-﻿namespace Tudormobile.Strava.Api;
+﻿using Tudormobile.Strava.Model;
+
+namespace Tudormobile.Strava.Api;
 
 /// <summary>
 /// Strava V3 Uploads API Interface.
 /// </summary>
-public interface IUploadsApi : IStravaApi
+public interface IUploadsApi
 {
+    /// <summary>
+    /// Gets the status of an upload by its unique identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier of the upload.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>An <see cref="ApiResult{Upload}"/> containing the upload status.</returns>
+    Task<ApiResult<Upload>> GetUploadAsync(long id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Uploads an activity file to Strava.
+    /// </summary>
+    /// <param name="filename">The path to the activity file to upload.</param>
+    /// <param name="name">The name of the activity.</param>
+    /// <param name="description">The description of the activity.</param>
+    /// <param name="trainer">Set to "1" if the activity was performed on a trainer, otherwise "0".</param>
+    /// <param name="commute">Set to "1" if the activity was a commute, otherwise "0".</param>
+    /// <param name="dataType">The format of the uploaded file (e.g., "fit", "gpx", "tcx").</param>
+    /// <param name="externalId">An identifier to associate with the upload for deduplication.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>An <see cref="ApiResult{Upload}"/> containing the upload status.</returns>
+    Task<ApiResult<Upload>> UploadActivityAsync(string filename, string name, string description, string trainer, string commute, string dataType, string externalId, CancellationToken cancellationToken = default);
+}
+
+internal partial class StravaApiImpl
+{
+    /// <inheritdoc/>
+    public Task<ApiResult<Upload>> GetUploadAsync(long id, CancellationToken cancellationToken = default)
+        => GetApiResultAsync<Upload>($"/uploads/{id}", cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<ApiResult<Upload>> UploadActivityAsync(string filename, string name, string description, string trainer, string commute, string dataType, string externalId, CancellationToken cancellationToken = default)
+    {
+        using var stream = File.OpenRead(filename);
+        using var content = new MultipartFormDataContent
+        {
+            { new StringContent(name), "name" },
+            { new StringContent(description), "description" },
+            { new StringContent(trainer), "trainer" },
+            { new StringContent(commute), "commute" },
+            { new StringContent(dataType), "data_type" },
+            { new StringContent(externalId), "external_id" },
+            { new StreamContent(stream), "file" }
+        };
+        return PostApiResultAsync<Upload>("/uploads", content, cancellationToken);
+    }
 }

--- a/src/Strava/Api/StravaApi.cs
+++ b/src/Strava/Api/StravaApi.cs
@@ -6,7 +6,7 @@ using Tudormobile.Strava.Model;
 
 namespace Tudormobile.Strava.Api;
 
-internal partial class StravaApiImpl : IActivitiesApi, IAthletesApi, IClubsApi, IGearsApi, ISegmentsApi, IRoutesApi, IDisposable
+internal partial class StravaApiImpl : IActivitiesApi, IAthletesApi, IClubsApi, IGearsApi, ISegmentsApi, IRoutesApi, IUploadsApi, IStreamsApi, IDisposable
 {
     private readonly string STRAVA_API_BASE_URL = "https://www.strava.com/api/v3";
     private readonly StravaSession _session;

--- a/src/Strava/Converters/SegmentStreamCollectionConverter.cs
+++ b/src/Strava/Converters/SegmentStreamCollectionConverter.cs
@@ -1,0 +1,103 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using Tudormobile.Strava.Model;
+
+namespace Tudormobile.Strava.Converters;
+
+/// <summary>
+/// Converts <see cref="SegmentStreamCollection"/> objects to and from JSON using custom serialization logic.
+/// </summary>
+/// <remarks>
+/// This converter enables serialization and deserialization of <see cref="SegmentStreamCollection"/> instances when
+/// working with System.Text.Json. It inspects the "type" property of each stream object in the JSON array to determine
+/// whether to deserialize as a <see cref="SegmentStream"/> (when "type" is "latlng") or as a <see cref="SegmentEffortStream"/>.
+/// Register this converter with a <see cref="JsonSerializerOptions"/> instance to ensure correct handling of
+/// <see cref="SegmentStreamCollection"/> types during JSON operations.
+/// </remarks>
+public class SegmentStreamCollectionConverter : JsonConverter<SegmentStreamCollection>
+{
+    /// <summary>
+    /// Reads and converts the JSON array to a <see cref="SegmentStreamCollection"/> instance.
+    /// </summary>
+    /// <param name="reader">The reader to read from.</param>
+    /// <param name="typeToConvert">The type to convert.</param>
+    /// <param name="options">The serializer options.</param>
+    /// <returns>The deserialized <see cref="SegmentStreamCollection"/>.</returns>
+    /// <exception cref="JsonException">Thrown if the JSON is not in the expected format.</exception>
+    public override SegmentStreamCollection? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartArray)
+        {
+            throw new JsonException("Expected start of array for SegmentStreamCollection.");
+        }
+
+        var collection = new SegmentStreamCollection();
+
+        // Read each element in the array
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndArray)
+                break;
+
+            // Clone the reader to peek at the "type" property
+            var elementReader = reader;
+
+            if (elementReader.TokenType != JsonTokenType.StartObject)
+                throw new JsonException("Expected start of object in SegmentStreamCollection array.");
+
+            // Read the object to find the "type" property
+            string? typeValue = null;
+            using (var doc = JsonDocument.ParseValue(ref elementReader))
+            {
+                if (doc.RootElement.TryGetProperty("type", out var typeProp))
+                {
+                    typeValue = typeProp.GetString();
+                }
+            }
+
+            // Deserialize based on the "type" property
+            if (string.Equals(typeValue, "latlng", StringComparison.OrdinalIgnoreCase))
+            {
+                var segmentStream = JsonSerializer.Deserialize<SegmentStream>(ref reader, options);
+                if (segmentStream != null)
+                    collection.Add(segmentStream);
+            }
+            else
+            {
+                var effortStream = JsonSerializer.Deserialize<SegmentEffortStream>(ref reader, options);
+                if (effortStream != null)
+                    collection.Add(effortStream);
+            }
+        }
+
+        return collection;
+    }
+
+    /// <summary>
+    /// Writes a <see cref="SegmentStreamCollection"/> instance to JSON.
+    /// </summary>
+    /// <param name="writer">The writer to write to.</param>
+    /// <param name="value">The <see cref="SegmentStreamCollection"/> value to write.</param>
+    /// <param name="options">The serializer options.</param>
+    public override void Write(Utf8JsonWriter writer, SegmentStreamCollection value, JsonSerializerOptions options)
+    {
+        writer.WriteStartArray();
+        foreach (var stream in value)
+        {
+            if (stream is SegmentStream segmentStream)
+            {
+                JsonSerializer.Serialize(writer, segmentStream, options);
+            }
+            else if (stream is SegmentEffortStream effortStream)
+            {
+                JsonSerializer.Serialize(writer, effortStream, options);
+            }
+            else
+            {
+                // Fallback: serialize as base type
+                JsonSerializer.Serialize(writer, stream, stream.GetType(), options);
+            }
+        }
+        writer.WriteEndArray();
+    }
+}

--- a/src/Strava/Documents/TcxDocument.cs
+++ b/src/Strava/Documents/TcxDocument.cs
@@ -21,7 +21,7 @@ public class TcxDocument : XmlDocumentBase
     /// <summary>
     /// Gets the collection of activities contained in the TCX document.
     /// </summary>
-    public IEnumerable<TcxActivity> Activities => _root.Element(_root.GetDefaultNamespace() + "Activities")?.Elements(_root.GetDefaultNamespace() + "Activity").Select(x => new TcxActivity(x)) ?? Enumerable.Empty<TcxActivity>();
+    public IEnumerable<TcxActivity> Activities => _root.Element(_root.GetDefaultNamespace() + "Activities")?.Elements(_root.GetDefaultNamespace() + "Activity").Select(x => new TcxActivity(x)) ?? [];
 
     /// <summary>
     /// Represents an activity in a TCX document, containing sport type, identifier, and lap data.

--- a/src/Strava/Model/ActivityStream.cs
+++ b/src/Strava/Model/ActivityStream.cs
@@ -1,0 +1,12 @@
+﻿namespace Tudormobile.Strava.Model;
+
+/// <summary>
+/// Represents a stream of activity data as a collection of double-precision values.
+/// </summary>
+public class ActivityStream : StreamBase
+{
+    /// <summary>
+    /// Gets or sets the collection of data values.
+    /// </summary>
+    public List<double> Data { get; set; } = [];
+}

--- a/src/Strava/Model/LatLng.cs
+++ b/src/Strava/Model/LatLng.cs
@@ -13,7 +13,7 @@ public struct LatLng
     /// <param name="coords">A tuple where the first element is the latitude and the second element is the longitude, both specified as
     /// double-precision floating-point values.</param>
     public static implicit operator LatLng((double Latitude, double Longitude) coords)
-        => new LatLng
+        => new()
         {
             Latitude = coords.Latitude,
             Longitude = coords.Longitude

--- a/src/Strava/Model/RouteStream.cs
+++ b/src/Strava/Model/RouteStream.cs
@@ -1,0 +1,14 @@
+﻿namespace Tudormobile.Strava.Model;
+
+/// <summary>
+/// Represents a stream of geographic route points as a collection of latitude and longitude coordinates.
+/// </summary>
+/// <remarks>Use this class to store or manipulate a sequence of route points, typically for mapping or navigation
+/// scenarios. Inherits from StreamBase, which may provide additional stream-related functionality.</remarks>
+public class RouteStream : StreamBase
+{
+    /// <summary>
+    /// Gets or sets the collection of geographic coordinates represented as latitude and longitude pairs.
+    /// </summary>
+    public List<LatLng> Data { get; set; } = [];
+}

--- a/src/Strava/Model/SegmentEffortStream.cs
+++ b/src/Strava/Model/SegmentEffortStream.cs
@@ -1,0 +1,19 @@
+﻿namespace Tudormobile.Strava.Model;
+
+/// <summary>
+/// Represents a stream of numeric data (e.g., heart rate, power, etc.) for a segment effort in Strava.
+/// </summary>
+/// <remarks>
+/// Inherits common stream metadata from <see cref="StreamBase"/>. The <see cref="Data"/> property contains
+/// the time-series values for the segment effort.
+/// </remarks>
+public class SegmentEffortStream : StreamBase
+{
+    /// <summary>
+    /// Gets or sets the list of numeric data points for the segment effort stream.
+    /// </summary>
+    /// <remarks>
+    /// Each value represents a measurement (such as heart rate, cadence, or power) at a specific point in the segment effort.
+    /// </remarks>
+    public List<double> Data { get; set; } = [];
+}

--- a/src/Strava/Model/SegmentStream.cs
+++ b/src/Strava/Model/SegmentStream.cs
@@ -1,0 +1,28 @@
+﻿namespace Tudormobile.Strava.Model;
+
+/// <summary>
+/// Represents a stream of geographic coordinates (latitude/longitude pairs) for a segment in Strava.
+/// </summary>
+/// <remarks>
+/// Inherits common stream metadata from <see cref="StreamBase"/>. The <see cref="Data"/> property contains
+/// the time-series of <see cref="LatLng"/> points that define the segment's path.
+/// </remarks>
+public class SegmentStream : StreamBase
+{
+    /// <summary>
+    /// Gets or sets the list of latitude/longitude coordinate pairs for the segment stream.
+    /// </summary>
+    /// <remarks>
+    /// Each <see cref="LatLng"/> represents a point along the segment's route.
+    /// </remarks>
+    public List<List<double>> Data { get; set; } = [];
+
+    /// <summary>
+    /// Gets the geographic coordinates represented by this instance.
+    /// </summary>
+    public List<LatLng> Points => [.. Data.Select(data => new LatLng
+    {
+        Latitude = data[0],
+        Longitude = data[1]
+    })];
+}

--- a/src/Strava/Model/SegmentStreamCollection.cs
+++ b/src/Strava/Model/SegmentStreamCollection.cs
@@ -1,0 +1,8 @@
+﻿namespace Tudormobile.Strava.Model;
+
+/// <summary>
+/// Gets or sets the collection of segment streams contained in this collection.
+/// </summary>
+public class SegmentStreamCollection : List<StreamBase>
+{
+}

--- a/src/Strava/Model/StreamBase.cs
+++ b/src/Strava/Model/StreamBase.cs
@@ -1,0 +1,43 @@
+﻿namespace Tudormobile.Strava.Model;
+
+/// <summary>
+/// Base class for all Strava stream types, providing common stream metadata properties.
+/// </summary>
+/// <remarks>
+/// Streams represent time-series data associated with an activity, such as GPS coordinates, altitude, heart rate, etc.
+/// This base class defines the common metadata for all stream types.
+/// </remarks>
+public class StreamBase
+{
+    /// <summary>
+    /// Gets or sets the type of stream (e.g., "time", "latlng", "distance", "altitude", "velocity_smooth", "heartrate", "cadence", "watts", "temp", "moving", "grade_smooth").
+    /// </summary>
+    /// <remarks>
+    /// The type determines the kind of data contained in the stream.
+    /// </remarks>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the series type for the stream (e.g., "distance", "time").
+    /// </summary>
+    /// <remarks>
+    /// Indicates how the stream data is indexed or sampled.
+    /// </remarks>
+    public string SeriesType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the original size of the stream data.
+    /// </summary>
+    /// <remarks>
+    /// Represents the number of data points in the original stream as returned by the Strava API.
+    /// </remarks>
+    public long OriginalSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the resolution of the stream (e.g., "low", "medium", "high").
+    /// </summary>
+    /// <remarks>
+    /// The resolution indicates the level of detail in the stream data.
+    /// </remarks>
+    public string Resolution { get; set; } = string.Empty;
+}

--- a/src/Strava/Model/Upload.cs
+++ b/src/Strava/Model/Upload.cs
@@ -1,0 +1,43 @@
+﻿namespace Tudormobile.Strava.Model;
+
+/// <summary>
+/// Represents the result of a file upload to Strava, including status and error information.
+/// </summary>
+/// <remarks>
+/// This class is used to track the state and outcome of an upload operation, such as a FIT, TCX, or GPX file.
+/// </remarks>
+public class Upload
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for the upload.
+    /// </summary>
+    public long Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the activity created by this upload, if available.
+    /// </summary>
+    public long ActivityId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the string representation of the upload identifier.
+    /// </summary>
+    public string IdStr { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the external identifier for the uploaded file (e.g., filename).
+    /// </summary>
+    public string ExternalId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the error message if the upload failed, or <c>null</c> if no error occurred.
+    /// </summary>
+    public string Error { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the status message describing the current state of the upload.
+    /// </summary>
+    /// <remarks>
+    /// Typical values include "Your activity is ready.", "Your activity is still being processed.", or an error message.
+    /// </remarks>
+    public string Status { get; set; } = string.Empty;
+}

--- a/src/Strava/StravaSerializer.cs
+++ b/src/Strava/StravaSerializer.cs
@@ -24,6 +24,7 @@ public static class StravaSerializer
             new Converters.FrameTypesConverter(),
             new Converters.SportTypesConverter(),
             new Converters.LatLngConverter(),
+            new Converters.SegmentStreamCollectionConverter()
         }
     };
 


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the Streams and Uploads APIs, as well as for model and converter classes related to segment streams and segment effort streams. It also updates existing tests to reflect new implementations and corrects minor test logic. The main focus is on ensuring robust coverage for serialization/deserialization, API integration, and model behaviors.

**New API Test Coverage**

* Added `StreamsApiTests` to verify correct behavior for activity, segment effort, and segment streams endpoints, including request construction and response handling.
* Added `UploadsApiTests` to test activity upload and retrieval endpoints, including file handling and result validation.

**Model and Converter Test Coverage**

* Added `SegmentStreamTests` and `SegmentEffortStreamTests` to validate constructors, property assignments, inheritance, and JSON deserialization for stream-related models. [[1]](diffhunk://#diff-88796f158b31a034f72ec172c7610de2f69bcb936a433ba3afa6c52ca4da45b1R1-R134) [[2]](diffhunk://#diff-388773280fc6d856ff10298e53b6cb9bc0a6621945604bc8cc0466403b182ac3R1-R127)
* Added `SegmentStreamCollectionConverterTests` to verify deserialization of collections containing multiple stream types.

**Test Logic and Minor Corrections**

* Updated `ApiExtensionsTests` to check for correct API interface types instead of throwing `NotImplementedException`.
* Minor corrections in existing tests, such as using tuple deconstruction for positions and updating default value assertions. [[1]](diffhunk://#diff-05c684c21b1ef9674cdd9af64211d471fe0b1a0411610f42e8879cc990123d80L110-R114) [[2]](diffhunk://#diff-95e4ee347c0d3d1cf70331c9af7b0d4cb5db98af4155283450191881e7dc716eL96-R96) [[3]](diffhunk://#diff-5dad7c8a1ce8085928d6a7b5f7baaf718bccd8acf08db0ee0982c94329c0643eL512-R512)

**Interface Clean-up**

* Commented out unused API interfaces in `IStravaClient` to reflect current implementation status.